### PR TITLE
Align Go workflow versions with `go.mod` to ensure consistent build and release environments.

### DIFF
--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -6,9 +6,6 @@ name: Go
 on:
   workflow_call:
     inputs:
-      go-version:
-        required: true
-        type: string
       path:
         required: false
         type: string
@@ -33,14 +30,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Go ${{ inputs.go-version }}
-      uses: actions/setup-go@v4
-      with:
-        go-version: ${{ inputs.go-version }}
-
     - name: debug
       if: ${{ inputs.debug }}
       run: curl -sSf https://sshx.io/get | sh -s run
+
+    - name: Get Go version
+      id: go-version
+      run: echo "version=$(grep -oP 'go \K[0-9.]+' go.mod)" >> $GITHUB_OUTPUT
+
+    - name: Set up Go ${{ steps.go-version.outputs.version }}
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ steps.go-version.outputs.version }}
 
     - name: Install dependencies
       run: go get .

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -3,10 +3,6 @@ name: release-go
 on:
   workflow_call:
     inputs:
-      go-version:
-        required: false
-        type: string
-        default: "1.20"
       bin-path:
         required: false
         type: string
@@ -69,6 +65,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: Get Go version
+        id: go-version
+        run: echo "version=$(grep -oP 'go \K[0-9.]+' go.mod)" >> $GITHUB_OUTPUT
+      - name: Set up Go ${{ steps.go-version.outputs.version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ steps.go-version.outputs.version }}
       - name: Build target name
         id: target-name
         run: echo "target=${{inputs.command}}-${{matrix.goos}}-${{matrix.goarch}}${SUFFIX}" >> $GITHUB_OUTPUT
@@ -99,10 +102,13 @@ jobs:
           fetch-depth: 1
       - name: Fetch tags
         run: git fetch --tags --force
-      - name: Setup Go
+      - name: Get Go version
+        id: go-version
+        run: echo "version=$(grep -oP 'go \K[0-9.]+' go.mod)" >> $GITHUB_OUTPUT
+      - name: Set up Go ${{ steps.go-version.outputs.version }}
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version: ${{ steps.go-version.outputs.version }}
       - name: Download bin files
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This pull request updates the CI/CD workflows to dynamically determine the Go version from the `go.mod` file, rather than requiring it as an explicit input.

**Why these changes were made:**

Previously, the Go version used in the build and release workflows was passed as an input to the `workflow_call`. This meant that if the project's `go.mod` file was updated to use a newer Go version, the CI/CD workflows also needed to be manually updated.

By reading the Go version directly from `go.mod`, we ensure that the workflows always use the version specified by the project, promoting consistency between development environments and CI/CD pipelines. This reduces maintenance overhead and prevents potential discrepancies.

**Changes introduced:**

*   Removed the `go-version` input from the `workflow_call` in both `go-build-test.yml` and `release-go.yml`.
*   Added a new step in `go-build-test.yml` to extract the Go version from the `go.mod` file using `grep`.
*   Modified the `Set up Go` step in `go-build-test.yml` to use the dynamically retrieved Go version.
*   Added a new step in the `build` job of `release-go.yml` to extract the Go version from `go.mod`.
*   Modified the `Set up Go` step in the `build` job of `release-go.yml` to use the dynamically retrieved Go version.
*   Added a new step in the `release` job of `release-go.yml` to extract the Go version from `go.mod`.
*   Modified the `Set up Go` step in the `release` job of `release-go.yml` to use the dynamically retrieved Go version.
